### PR TITLE
Feature/add dash segment packet side data

### DIFF
--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2327,7 +2327,10 @@ static void recheck_discard_flags(AVFormatContext *s, struct representation **p,
 
 static int dash_read_packet(AVFormatContext *s, AVPacket *pkt)
 {
+    AVDictionary* metadata_dict = NULL;
+    uint8_t* metadata_dict_packed = NULL;
     DASHContext *c = s->priv_data;
+    int metadata_dict_size = 0;
     int ret = 0, i;
     int64_t mints = 0;
     struct representation *cur = NULL;
@@ -2388,20 +2391,18 @@ static int dash_read_packet(AVFormatContext *s, AVPacket *pkt)
         }
     }
 
-    AVDictionary* metadata_dict = NULL;
-    av_dict_set_int(&metadata_dict, "segNumber", cur->cur_seq_no);
-    av_dict_set_int(&metadata_dict, "segSize", cur->cur_seg_size);
-    av_dict_set_int(&metadata_dict, "fragTimescale", cur->fragment_timescale);
+    av_dict_set_int(&metadata_dict, "segNumber", cur->cur_seq_no, 0);
+    av_dict_set_int(&metadata_dict, "segSize", cur->cur_seg_size, 0);
+    av_dict_set_int(&metadata_dict, "fragTimescale", cur->fragment_timescale, 0);
 
     if (cur->n_timelines) {
-        av_dict_set_int(&metadata_dict, "fragDuration", cur->timelines[0]->duration);
+        av_dict_set_int(&metadata_dict, "fragDuration", cur->timelines[0]->duration, 0);
     }
     else {
-        av_dict_set_int(&metadata_dict, "fragDuration", cur->fragment_duration);
+        av_dict_set_int(&metadata_dict, "fragDuration", cur->fragment_duration, 0);
     }
 
-    int metadata_dict_size = 0;
-    uint8_t* metadata_dict_packed = av_packet_pack_dictionary(metadata_dict, &metadata_dict_size);
+    metadata_dict_packed = av_packet_pack_dictionary(metadata_dict, &metadata_dict_size);
     av_dict_free(&metadata_dict);
     av_packet_add_side_data(pkt, AV_PKT_DATA_STRINGS_METADATA, metadata_dict_packed, metadata_dict_size);
 

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -2379,6 +2379,22 @@ static int dash_read_packet(AVFormatContext *s, AVPacket *pkt)
             /* If we got a packet, return it */
             cur->cur_timestamp = av_rescale(pkt->pts, (int64_t)cur->ctx->streams[0]->time_base.num * 90000, cur->ctx->streams[0]->time_base.den);
             pkt->stream_index = cur->stream_index;
+
+            av_dict_set_int(&metadata_dict, "segNumber", cur->cur_seq_no, 0);
+            av_dict_set_int(&metadata_dict, "segSize", cur->cur_seg_size, 0);
+            av_dict_set_int(&metadata_dict, "fragTimescale", cur->fragment_timescale, 0);
+
+            if (cur->n_timelines) {
+                av_dict_set_int(&metadata_dict, "fragDuration", cur->timelines[0]->duration, 0);
+            }
+            else {
+                av_dict_set_int(&metadata_dict, "fragDuration", cur->fragment_duration, 0);
+            }
+
+            metadata_dict_packed = av_packet_pack_dictionary(metadata_dict, &metadata_dict_size);
+            av_dict_free(&metadata_dict);
+            av_packet_add_side_data(pkt, AV_PKT_DATA_STRINGS_METADATA, metadata_dict_packed, metadata_dict_size);
+
             return 0;
         }
         if (cur->is_restart_needed) {
@@ -2390,21 +2406,6 @@ static int dash_read_packet(AVFormatContext *s, AVPacket *pkt)
             cur->is_restart_needed = 0;
         }
     }
-
-    av_dict_set_int(&metadata_dict, "segNumber", cur->cur_seq_no, 0);
-    av_dict_set_int(&metadata_dict, "segSize", cur->cur_seg_size, 0);
-    av_dict_set_int(&metadata_dict, "fragTimescale", cur->fragment_timescale, 0);
-
-    if (cur->n_timelines) {
-        av_dict_set_int(&metadata_dict, "fragDuration", cur->timelines[0]->duration, 0);
-    }
-    else {
-        av_dict_set_int(&metadata_dict, "fragDuration", cur->fragment_duration, 0);
-    }
-
-    metadata_dict_packed = av_packet_pack_dictionary(metadata_dict, &metadata_dict_size);
-    av_dict_free(&metadata_dict);
-    av_packet_add_side_data(pkt, AV_PKT_DATA_STRINGS_METADATA, metadata_dict_packed, metadata_dict_size);
 
     return AVERROR_EOF;
 }

--- a/libavformat/dashdec.c
+++ b/libavformat/dashdec.c
@@ -1686,7 +1686,6 @@ static struct fragment *get_current_fragment(struct representation *pls)
             return seg;
         } else if (c->is_live) {
             refresh_manifest(pls->parent);
-
         } else {
             break;
         }
@@ -2381,7 +2380,9 @@ static int dash_read_packet(AVFormatContext *s, AVPacket *pkt)
             pkt->stream_index = cur->stream_index;
 
             av_dict_set_int(&metadata_dict, "segNumber", cur->cur_seq_no, 0);
-            av_dict_set_int(&metadata_dict, "segSize", cur->cur_seg_size, 0);
+            if (NULL != cur->cur_seg) {
+                av_dict_set_int(&metadata_dict, "segSize", cur->cur_seg->size, 0);
+            }
             av_dict_set_int(&metadata_dict, "fragTimescale", cur->fragment_timescale, 0);
 
             if (cur->n_timelines) {


### PR DESCRIPTION
 dashdec: add segment data as packet metadata
    
    Instead of requiring the consumer to use the FFmpeg internal structures
    in an unsafe manner to get segement information, attach it to each
    packet