### PR TITLE
Implement HEVC parallel tile decoding

### DIFF
--- a/libavcodec/hevc_filter.c
+++ b/libavcodec/hevc_filter.c
@@ -712,7 +712,7 @@ static int boundary_strength(HEVCContext *s, MvField *curr, MvField *neigh,
 }
 
 void ff_hevc_deblocking_boundary_strengths(HEVCContext *s, int x0, int y0,
-                                           int log2_trafo_size)
+                                           int log2_trafo_size, int do_internal)
 {
     HEVCLocalContext *lc = s->HEVClc;
     MvField *tab_mvf     = s->ref->tab_mvf;
@@ -745,6 +745,9 @@ void ff_hevc_deblocking_boundary_strengths(HEVCContext *s, int x0, int y0,
         int yq_tu =  y0      >> log2_min_tu_size;
 
             for (i = 0; i < (1 << log2_trafo_size); i += 4) {
+                if (x0 + i + 4 > s->ps.sps->width) {
+                    continue;
+                }
                 int x_pu = (x0 + i) >> log2_min_pu_size;
                 int x_tu = (x0 + i) >> log2_min_tu_size;
                 MvField *top  = &tab_mvf[yp_pu * min_pu_width + x_pu];
@@ -783,6 +786,9 @@ void ff_hevc_deblocking_boundary_strengths(HEVCContext *s, int x0, int y0,
         int xq_tu =  x0      >> log2_min_tu_size;
 
             for (i = 0; i < (1 << log2_trafo_size); i += 4) {
+                if (y0 + i + 4 > s->ps.sps->height) {
+                    continue;
+                }
                 int y_pu      = (y0 + i) >> log2_min_pu_size;
                 int y_tu      = (y0 + i) >> log2_min_tu_size;
                 MvField *left = &tab_mvf[y_pu * min_pu_width + xp_pu];
@@ -800,7 +806,7 @@ void ff_hevc_deblocking_boundary_strengths(HEVCContext *s, int x0, int y0,
             }
     }
 
-    if (log2_trafo_size > log2_min_pu_size && !is_intra) {
+    if (log2_trafo_size > log2_min_pu_size && !is_intra && do_internal) {
         RefPicList *rpl = s->ref->refPicList;
 
         // bs for TU internal horizontal PU boundaries

--- a/libavcodec/hevcdec.c
+++ b/libavcodec/hevcdec.c
@@ -870,8 +870,7 @@ static int hls_slice_header(HEVCContext *s)
                 sh->entry_point_offset[i] = val + 1; // +1; // +1 to get the size
             }
             if (s->threads_number > 1 && (s->ps.pps->num_tile_rows > 1 || s->ps.pps->num_tile_columns > 1)) {
-                s->enable_parallel_tiles = 0; // TODO: you can enable tiles in parallel here
-                s->threads_number = 1;
+                s->enable_parallel_tiles = 1;
             } else
                 s->enable_parallel_tiles = 0;
         } else
@@ -1364,7 +1363,7 @@ do {                                                                            
                 }
         }
         if (!s->sh.disable_deblocking_filter_flag) {
-            ff_hevc_deblocking_boundary_strengths(s, x0, y0, log2_trafo_size);
+            ff_hevc_deblocking_boundary_strengths(s, x0, y0, log2_trafo_size, 1);
             if (s->ps.pps->transquant_bypass_enable_flag &&
                 lc->cu.cu_transquant_bypass_flag)
                 set_deblocking_bypass(s, x0, y0, log2_trafo_size);
@@ -1393,7 +1392,7 @@ static int hls_pcm_sample(HEVCContext *s, int x0, int y0, int log2_cb_size)
     int ret;
 
     if (!s->sh.disable_deblocking_filter_flag)
-        ff_hevc_deblocking_boundary_strengths(s, x0, y0, log2_cb_size);
+        ff_hevc_deblocking_boundary_strengths(s, x0, y0, log2_cb_size, 1);
 
     ret = init_get_bits(&gb, pcm, length);
     if (ret < 0)
@@ -2157,7 +2156,7 @@ static int hls_coding_unit(HEVCContext *s, int x0, int y0, int log2_cb_size)
         intra_prediction_unit_default_value(s, x0, y0, log2_cb_size);
 
         if (!s->sh.disable_deblocking_filter_flag)
-            ff_hevc_deblocking_boundary_strengths(s, x0, y0, log2_cb_size);
+            ff_hevc_deblocking_boundary_strengths(s, x0, y0, log2_cb_size, 1);
     } else {
         int pcm_flag = 0;
 
@@ -2245,7 +2244,7 @@ static int hls_coding_unit(HEVCContext *s, int x0, int y0, int log2_cb_size)
                     return ret;
             } else {
                 if (!s->sh.disable_deblocking_filter_flag)
-                    ff_hevc_deblocking_boundary_strengths(s, x0, y0, log2_cb_size);
+                    ff_hevc_deblocking_boundary_strengths(s, x0, y0, log2_cb_size, 1);
             }
         }
     }
@@ -2631,6 +2630,7 @@ static int hls_slice_data_wpp(HEVCContext *s, const H2645NAL *nal)
     for (i = 1; i < s->threads_number; i++) {
         s->sList[i]->HEVClc->first_qp_group = 1;
         s->sList[i]->HEVClc->qp_y = s->sList[0]->HEVClc->qp_y;
+        s->sList[i]->HEVClc->gb = s->sList[0]->HEVClc->gb;
         memcpy(s->sList[i], s, sizeof(HEVCContext));
         s->sList[i]->HEVClc = s->HEVClcList[i];
     }
@@ -2648,6 +2648,221 @@ static int hls_slice_data_wpp(HEVCContext *s, const H2645NAL *nal)
 
     for (i = 0; i <= s->sh.num_entry_point_offsets; i++)
         res += ret[i];
+error:
+    av_free(ret);
+    av_free(arg);
+    return res;
+}
+
+/* Does this CTB abut another tile? */
+static int is_boundary_left_tile(HEVCContext* s, int ctb_addr_ts)
+{ 
+    int ctb_addr_rs = s->ps.pps->ctb_addr_ts_to_rs[ctb_addr_ts];
+
+    return ctb_addr_rs % s->ps.sps->ctb_width > 0 &&
+           s->ps.pps->tile_id[ctb_addr_ts] !=
+           s->ps.pps->tile_id[s->ps.pps->ctb_addr_rs_to_ts[ctb_addr_rs-1]];
+}
+
+static int is_boundary_upper_tile(HEVCContext* s, int ctb_addr_ts)
+{ 
+    int ctb_addr_rs = s->ps.pps->ctb_addr_ts_to_rs[ctb_addr_ts];
+
+    return ctb_addr_rs / s->ps.sps->ctb_width > 0 &&
+           s->ps.pps->tile_id[ctb_addr_ts] !=
+           s->ps.pps->tile_id[s->ps.pps->ctb_addr_rs_to_ts[ctb_addr_rs - s->ps.sps->ctb_width]];
+}
+
+static int hls_decode_entry_tiles(AVCodecContext *avctxt, void *input_tile, int job, int self_id)
+{
+    HEVCContext *s1  = avctxt->priv_data, *s;
+    HEVCLocalContext *lc;
+    int ctb_size    = 1<< s1->ps.sps->log2_ctb_size;
+    int more_data   = 1;
+    int *tile_p    = input_tile;
+    int tile = tile_p[job];
+
+    int slice_start_tile = s1->ps.pps->tile_id[s1->ps.pps->ctb_addr_rs_to_ts[s1->sh.slice_ctb_addr_rs]];
+    int ctb_addr_rs = s1->ps.pps->tile_pos_rs[slice_start_tile + tile];
+    int ctb_addr_ts = s1->ps.pps->ctb_addr_rs_to_ts[ctb_addr_rs];
+    int ret;
+
+    s = s1->sList[self_id];
+    lc = s->HEVClc;
+
+    if (tile) {
+        ret = init_get_bits8(&lc->gb, s->data + s->sh.offset[tile - 1], s->sh.size[tile - 1]);
+        if (ret < 0) {
+            goto error;
+        }
+    }
+
+    while(more_data && ctb_addr_ts < s->ps.sps->ctb_size) {
+        int x_ctb = (ctb_addr_rs % s->ps.sps->ctb_width) << s->ps.sps->log2_ctb_size;
+        int y_ctb = (ctb_addr_rs / s->ps.sps->ctb_width) << s->ps.sps->log2_ctb_size;
+
+        hls_decode_neighbour(s, x_ctb, y_ctb, ctb_addr_ts);
+        ret = ff_hevc_cabac_init(s, ctb_addr_ts);
+        if (ret < 0)
+            goto error;
+
+        hls_sao_param(s, x_ctb >> s->ps.sps->log2_ctb_size, y_ctb >> s->ps.sps->log2_ctb_size);
+        s->deblock[ctb_addr_rs].beta_offset = s->sh.beta_offset;
+        s->deblock[ctb_addr_rs].tc_offset   = s->sh.tc_offset;
+        s->filter_slice_edges[ctb_addr_rs]  = s->sh.slice_loop_filter_across_slices_enabled_flag;
+
+        more_data = hls_coding_quadtree(s, x_ctb, y_ctb, s->ps.sps->log2_ctb_size, 0);
+
+        if (more_data < 0) {
+            ret = more_data;
+            goto error;
+        }
+        ctb_addr_ts++;
+        ff_hevc_save_states(s, ctb_addr_ts);
+
+        if ((x_ctb+ctb_size) >= s->ps.sps->width && (y_ctb+ctb_size) >= s->ps.sps->height) {
+            break;
+        }
+
+        if (s->ps.pps->tile_id[ctb_addr_ts] != s->ps.pps->tile_id[ctb_addr_ts-1]) {
+            break;
+        }
+        
+        ctb_addr_rs = s->ps.pps->ctb_addr_ts_to_rs[ctb_addr_ts];
+    }
+
+    return ctb_addr_ts;
+error:
+    s->tab_slice_address[ctb_addr_rs] = -1;
+    return ret;
+}
+
+static int slicecount = 0;
+
+static int hls_slice_data_tiles(HEVCContext *s, const H2645NAL *nal)
+{
+    const uint8_t *data = nal->data;
+    int length          = nal->size;
+    HEVCLocalContext *lc = s->HEVClc;
+    int *ret = av_malloc_array(s->sh.num_entry_point_offsets + 1, sizeof(int));
+    int *arg = av_malloc_array(s->sh.num_entry_point_offsets + 1, sizeof(int));
+    int64_t offset;
+    int64_t startheader, cmpt = 0;
+    int i, j, res = 0;
+
+    if (!ret || !arg) {
+        av_free(ret);
+        av_free(arg);
+        return AVERROR(ENOMEM);
+    }
+
+    ff_alloc_entries(s->avctx, s->sh.num_entry_point_offsets + 1);
+
+    if (!s->sList[1]) {
+        for (i = 1; i < s->threads_number; i++) {
+            s->sList[i] = av_malloc(sizeof(HEVCContext));
+            memcpy(s->sList[i], s, sizeof(HEVCContext));
+            s->HEVClcList[i] = av_mallocz(sizeof(HEVCLocalContext));
+            s->sList[i]->HEVClc = s->HEVClcList[i];
+        }
+    }
+
+    offset = (lc->gb.index >> 3);
+
+    for (j = 0, cmpt = 0, startheader = offset + s->sh.entry_point_offset[0]; j < nal->skipped_bytes; j++) {
+        if (nal->skipped_bytes_pos[j] >= offset && nal->skipped_bytes_pos[j] < startheader) {
+            startheader--;
+            cmpt++;
+        }
+    }
+    for (i = 1; i < s->sh.num_entry_point_offsets; i++) {
+        offset += (s->sh.entry_point_offset[i - 1] - cmpt);
+        for (j = 0, cmpt = 0, startheader = offset + s->sh.entry_point_offset[i]; j < nal->skipped_bytes; j++) {
+            if (nal->skipped_bytes_pos[j] >= offset && nal->skipped_bytes_pos[j] < startheader) {
+                startheader--;
+                cmpt++;
+            }
+        }
+        s->sh.size[i - 1] = s->sh.entry_point_offset[i] - cmpt;
+        s->sh.offset[i - 1] = offset;
+
+    }
+    if (s->sh.num_entry_point_offsets != 0) {
+        offset += s->sh.entry_point_offset[s->sh.num_entry_point_offsets - 1] - cmpt;
+        if (length < offset) {
+            av_log(s->avctx, AV_LOG_ERROR, "entry_point_offset table is corrupted\n");
+            res = AVERROR_INVALIDDATA;
+            goto error;
+        }
+        s->sh.size[s->sh.num_entry_point_offsets - 1] = length - offset;
+        s->sh.offset[s->sh.num_entry_point_offsets - 1] = offset;
+
+    }
+    s->data = data;
+
+    for (i = 1; i < s->threads_number; i++) {
+        /* Initialize the necessary parts of the local context object */
+        s->sList[i]->HEVClc->first_qp_group = 1;
+        s->sList[i]->HEVClc->qp_y = s->sList[0]->HEVClc->qp_y;
+        s->sList[i]->HEVClc->ctb_left_flag = s->sList[0]->HEVClc->ctb_left_flag ;
+        s->sList[i]->HEVClc->ctb_up_flag = s->sList[0]->HEVClc->ctb_up_flag ;
+        s->sList[i]->HEVClc->ctb_up_right_flag = s->sList[0]->HEVClc->ctb_up_right_flag ;
+        s->sList[i]->HEVClc->ctb_up_left_flag = s->sList[0]->HEVClc->ctb_up_left_flag ;
+        s->sList[i]->HEVClc->end_of_tiles_x = s->sList[0]->HEVClc->end_of_tiles_x ;
+        s->sList[i]->HEVClc->end_of_tiles_y = s->sList[0]->HEVClc->end_of_tiles_y ;
+        s->sList[i]->HEVClc->gb = s->sList[0]->HEVClc->gb;
+        memcpy(s->sList[i], s, sizeof(HEVCContext));
+        s->sList[i]->HEVClc = s->HEVClcList[i];
+    }
+
+    for (i = 0; i <= s->sh.num_entry_point_offsets; i++) {
+        arg[i] = i;
+        ret[i] = 0;
+    }
+
+    /* Parse the tiles in parallel */
+    if (s->ps.pps->tiles_enabled_flag) {
+        s->avctx->execute2(s->avctx, hls_decode_entry_tiles, arg, ret, s->sh.num_entry_point_offsets + 1);
+    }
+
+    for (i = 0; i <= s->sh.num_entry_point_offsets; i++) {
+        if (ret[i] < 0) {
+                res = ret[i];
+                goto error;
+        }
+        if (ret[i] > res) {
+            res = ret[i];
+        }
+    }
+
+    /* With the tiles parsed, do the filter operations on the tile boundaries */
+    int ctb_size    = 1 << s->ps.sps->log2_ctb_size;
+    int x_ctb       = 0;
+    int y_ctb       = 0;
+    int ctb_addr_ts = s->ps.pps->ctb_addr_rs_to_ts[s->sh.slice_ctb_addr_rs];
+
+    while (ctb_addr_ts < res && ctb_addr_ts < s->ps.sps->ctb_size) {
+        int ctb_addr_rs = s->ps.pps->ctb_addr_ts_to_rs[ctb_addr_ts];
+        x_ctb = (ctb_addr_rs % ((s->ps.sps->width + ctb_size - 1) >> s->ps.sps->log2_ctb_size)) << s->ps.sps->log2_ctb_size;
+        y_ctb = (ctb_addr_rs / ((s->ps.sps->width + ctb_size - 1) >> s->ps.sps->log2_ctb_size)) << s->ps.sps->log2_ctb_size;
+
+        if (is_boundary_upper_tile(s, ctb_addr_ts) || is_boundary_left_tile(s, ctb_addr_ts)) {
+            /* The parameters determined below depend on the decode of neighbouring CTBs, even across tiles.
+             * Re-compute them since it's now guaranteed that the left and upper neighbours are complete */
+            hls_decode_neighbour(s, x_ctb, y_ctb, ctb_addr_ts);
+            ff_hevc_deblocking_boundary_strengths(s, x_ctb, y_ctb, s->ps.sps->log2_ctb_size, 0);
+        }
+        ff_hevc_hls_filters(s, x_ctb, y_ctb, ctb_size);
+
+        ctb_addr_ts++;
+    }
+
+    if (x_ctb + ctb_size >= s->ps.sps->width &&
+        y_ctb + ctb_size >= s->ps.sps->height)
+    {
+        ff_hevc_hls_filter(s, x_ctb, y_ctb, ctb_size);
+    }
+
 error:
     av_free(ret);
     av_free(arg);
@@ -3009,8 +3224,14 @@ static int decode_nal_unit(HEVCContext *s, const H2645NAL *nal)
             if (ret < 0)
                 goto fail;
         } else {
-            if (s->threads_number > 1 && s->sh.num_entry_point_offsets > 0)
-                ctb_addr_ts = hls_slice_data_wpp(s, nal);
+            if (s->threads_number > 1 && s->sh.num_entry_point_offsets > 0) {
+                if (s->enable_parallel_tiles) {
+                    ctb_addr_ts = hls_slice_data_tiles(s, nal);
+                }
+                else {
+                    ctb_addr_ts = hls_slice_data_wpp(s, nal);
+                }
+            }
             else
                 ctb_addr_ts = hls_slice_data(s);
             if (ctb_addr_ts >= (s->ps.sps->ctb_width * s->ps.sps->ctb_height)) {

--- a/libavcodec/hevcdec.h
+++ b/libavcodec/hevcdec.h
@@ -471,6 +471,10 @@ typedef struct HEVCContext {
     int enable_parallel_tiles;
     atomic_int wpp_err;
 
+    /* Allow tiles and WPP to be disabled.  Enabled by default */
+    int allow_parallel_tiles;
+    int allow_parallel_wpp;
+
     const uint8_t *data;
 
     H2645Packet pkt;

--- a/libavcodec/hevcdec.h
+++ b/libavcodec/hevcdec.h
@@ -589,7 +589,7 @@ void ff_hevc_luma_mv_mvp_mode(HEVCContext *s, int x0, int y0,
 void ff_hevc_set_qPy(HEVCContext *s, int xBase, int yBase,
                      int log2_cb_size);
 void ff_hevc_deblocking_boundary_strengths(HEVCContext *s, int x0, int y0,
-                                           int log2_trafo_size);
+                                           int log2_trafo_size, int do_internal);
 int ff_hevc_cu_qp_delta_sign_flag(HEVCContext *s);
 int ff_hevc_cu_qp_delta_abs(HEVCContext *s);
 int ff_hevc_cu_chroma_qp_offset_flag(HEVCContext *s);

--- a/libavcodec/hevcpred_template.c
+++ b/libavcodec/hevcpred_template.c
@@ -30,6 +30,15 @@
 static av_always_inline void FUNC(intra_pred)(HEVCContext *s, int x0, int y0,
                                               int log2_size, int c_idx)
 {
+#define IS_AVAIL(x,y) \
+    ( \
+      (y >= size && x == -1) ? cand_bottom_left : \
+      (y >= 0 && x == -1) ? cand_left : \
+      (y == -1 && x == -1) ? cand_up_left : \
+      (y == -1 && x >= size) ? cand_up_right : \
+      (y == -1 && x >= 0) ? cand_up : \
+      1 \
+    )
 #define PU(x) \
     ((x) >> s->ps.sps->log2_min_pu_size)
 #define MVF(x, y) \
@@ -38,6 +47,8 @@ static av_always_inline void FUNC(intra_pred)(HEVCContext *s, int x0, int y0,
     MVF(PU(x0 + ((x) * (1 << hshift))), PU(y0 + ((y) * (1 << vshift))))
 #define IS_INTRA(x, y) \
     (MVF_PU(x, y).pred_flag == PF_INTRA)
+#define IS_AVAIL_AND_INTRA(x, y) \
+    (IS_AVAIL(x,y) && IS_INTRA(x,y))
 #define MIN_TB_ADDR_ZS(x, y) \
     s->ps.pps->min_tb_addr_zs[(y) * (s->ps.sps->tb_mask+2) + (x)]
 #define EXTEND(ptr, val, len)         \
@@ -49,23 +60,23 @@ do {                                  \
 
 #define EXTEND_RIGHT_CIP(ptr, start, length)                                   \
         for (i = start; i < (start) + (length); i += 4)                        \
-            if (!IS_INTRA(i, -1))                                              \
+            if (!IS_AVAIL_AND_INTRA(i, -1))                                              \
                 AV_WN4P(&ptr[i], a);                                           \
             else                                                               \
                 a = PIXEL_SPLAT_X4(ptr[i+3])
 #define EXTEND_LEFT_CIP(ptr, start, length) \
         for (i = start; i > (start) - (length); i--) \
-            if (!IS_INTRA(i - 1, -1)) \
+            if (!IS_AVAIL_AND_INTRA(i - 1, -1)) \
                 ptr[i - 1] = ptr[i]
 #define EXTEND_UP_CIP(ptr, start, length)                                      \
         for (i = (start); i > (start) - (length); i -= 4)                      \
-            if (!IS_INTRA(-1, i - 3))                                          \
+            if (!IS_AVAIL_AND_INTRA(-1, i - 3))                                          \
                 AV_WN4P(&ptr[i - 3], a);                                       \
             else                                                               \
                 a = PIXEL_SPLAT_X4(ptr[i - 3])
 #define EXTEND_DOWN_CIP(ptr, start, length)                                    \
         for (i = start; i < (start) + (length); i += 4)                        \
-            if (!IS_INTRA(-1, i))                                              \
+            if (!IS_AVAIL_AND_INTRA(-1, i))                                              \
                 AV_WN4P(&ptr[i], a);                                           \
             else                                                               \
                 a = PIXEL_SPLAT_X4(ptr[i + 3])
@@ -199,18 +210,18 @@ do {                                  \
                                                      size : (s->ps.sps->height - y0) >> vshift;
             }
             if (cand_bottom_left || cand_left || cand_up_left) {
-                while (j > -1 && !IS_INTRA(-1, j))
+                while (j > -1 && !IS_AVAIL_AND_INTRA(-1, j))
                     j--;
-                if (!IS_INTRA(-1, j)) {
+                if (!IS_AVAIL_AND_INTRA(-1, j)) {
                     j = 0;
-                    while (j < size_max_x && !IS_INTRA(j, -1))
+                    while (j < size_max_x && !IS_AVAIL_AND_INTRA(j, -1))
                         j++;
                     EXTEND_LEFT_CIP(top, j, j + 1);
                     left[-1] = top[-1];
                 }
             } else {
                 j = 0;
-                while (j < size_max_x && !IS_INTRA(j, -1))
+                while (j < size_max_x && !IS_AVAIL_AND_INTRA(j, -1))
                     j++;
                 if (j > 0)
                     if (x0 > 0) {
@@ -233,7 +244,7 @@ do {                                  \
             if (x0 != 0 && y0 != 0) {
                 a = PIXEL_SPLAT_X4(left[size_max_y - 1]);
                 EXTEND_UP_CIP(left, size_max_y - 1, size_max_y);
-                if (!IS_INTRA(-1, - 1))
+                if (!IS_AVAIL_AND_INTRA(-1, - 1))
                     left[-1] = left[0];
             } else if (x0 == 0) {
                 EXTEND(left, 0, size_max_y);
@@ -542,6 +553,8 @@ static void FUNC(pred_angular_3)(uint8_t *src, const uint8_t *top,
 #undef EXTEND_RIGHT_CIP
 #undef EXTEND_UP_CIP
 #undef EXTEND_DOWN_CIP
+#undef IS_AVAIL_AND_INTRA
+#undef IS_AVAIL
 #undef IS_INTRA
 #undef MVF_PU
 #undef MVF

--- a/libavcodec/pthread_slice.c
+++ b/libavcodec/pthread_slice.c
@@ -237,6 +237,8 @@ int ff_alloc_entries(AVCodecContext *avctx, int count)
 
 void ff_reset_entries(AVCodecContext *avctx)
 {
-    SliceThreadContext *p = avctx->internal->thread_ctx;
-    memset(p->entries, 0, p->entries_count * sizeof(int));
+    if (avctx->active_thread_type & FF_THREAD_SLICE)  {
+        SliceThreadContext *p = avctx->internal->thread_ctx;
+        memset(p->entries, 0, p->entries_count * sizeof(int));
+    }
 }


### PR DESCRIPTION
Implementing HEVC parallel tile decoding for FFmpeg.  This is a limiting factor in how fast we can process some 4K streams, leaving us falling behind with spare CPU.
See https://ssimwave.atlassian.net/wiki/spaces/EN/pages/1091076103/HEVC+Parallel+Tile+Decoding for a description of what's happening here.