### PR TITLE
libavformat: expose url.h publically

### DIFF
--- a/libavformat/Makefile
+++ b/libavformat/Makefile
@@ -4,6 +4,7 @@ DESC = FFmpeg container format library
 HEADERS = avformat.h                                                    \
           avio.h                                                        \
           version.h                                                     \
+          url.h                                                         \
 
 OBJS = allformats.o         \
        avio.o               \


### PR DESCRIPTION
This is required to modify the mpegts parser callback outside of ffmpeg